### PR TITLE
feat: リモートボタン連続押し対応 - ステータスをnoneにリセットしてHAオートメーション動作を改善

### DIFF
--- a/components/sesame_server/__init__.py
+++ b/components/sesame_server/__init__.py
@@ -11,7 +11,7 @@ CONFLICTS_WITH = ["esp32_ble"]
 
 CONF_TRIGGERS = "triggers"
 CONF_MAX_SESSIONS = "max_sessions"
-EVENT_TYPES = ["open", "close", "lock", "unlock"]
+EVENT_TYPES = ["open", "close", "lock", "unlock", "none"]
 
 sesame_server_ns = cg.esphome_ns.namespace("sesame_server")
 SesameServerComponent = sesame_server_ns.class_("SesameServerComponent", cg.PollingComponent)

--- a/components/sesame_server/sesame_server_component.cpp
+++ b/components/sesame_server/sesame_server_component.cpp
@@ -27,7 +27,8 @@ event_name(Sesame::item_code_t cmd) {
 			return "open";
 		case item_code_t::door_closed:
 			return "close";
-			break;
+		case item_code_t::none:
+			return "none";
 		default:
 			return "";
 	}
@@ -80,6 +81,10 @@ SesameServerComponent::on_command(const NimBLEAddress& addr,
 				if (!sesame_server.send_lock_status(last_status)) {
 					ESP_LOGW(TAG, "Failed to send lock status");
 				}
+			});
+			set_timeout(100, [this, target, tag, trigger_type]() {
+				ESP_LOGD(TAG, "Send To None");
+				(*target)->invoke(Sesame::item_code_t::none, tag, trigger_type);
 			});
 		}
 		return (*target)->invoke(cmd, tag, trigger_type);


### PR DESCRIPTION
## PR内容
リモートの同じボタンを連続で押した際に、HAのオートメーションが動作しなかったため、
オートメーションが動作するようにステータスをNoneに戻すように変更。

## 詳しい内容
HAのオートメーションで以下のようなトリガーを設定。
![image](https://github.com/user-attachments/assets/813c9602-686e-42d4-b8a2-e9ef74d6906a)
リモートのLockボタンを連続で押しても、最初の一度しかオートメーションが動作しなかった。

ステータスがすでにLockなので、変更がないと判断されオートメーションが動作しないと思い、
一度別のステータスに変えるようにしました。

・リモートのイベントが発火（Lock、Unlock）
・通常通りHAへ送信
・100ms後にステータス`None`を送信

ボタンを押す度にステータスがLock(or Unlock)→100ms後Noneになるので、連続で押してもオートメーションが動作するようになりました。
